### PR TITLE
Final fix for Hacks 6 site (Hopefully)

### DIFF
--- a/web/ugahacks-6/pages/components/HallOfFame/MediaCard.tsx
+++ b/web/ugahacks-6/pages/components/HallOfFame/MediaCard.tsx
@@ -16,8 +16,9 @@ interface MediaCardProps {
   buttonText: string;
 }
 
-const CustomButton = withStyles({
+const CardButton = withStyles({
   root: {
+    width: "250px",
     paddingLeft: "15px",
     paddingRight: "15px",
     fontSize: "1.1em",
@@ -47,7 +48,7 @@ export default function MediaCard(props: MediaCardProps): ReactElement {
         </CardContent>
       </CardActionArea>
       <CardActions className="card-action-container">
-        <CustomButton
+        <CardButton
           variant="contained"
           size="small"
           color="primary"
@@ -56,7 +57,7 @@ export default function MediaCard(props: MediaCardProps): ReactElement {
           <Typography variant="subtitle1" component="h6">
             {props.buttonText}
           </Typography>
-        </CustomButton>
+        </CardButton>
       </CardActions>
     </Card>
   );


### PR DESCRIPTION
### Description

Renamed the HOF button component since the styling was conflicting with the button in the Splash of the same name (didn't notice this before cause I was running run dev locally). This should be the last fix for the revamped hacks 6 site.


### What are you changing?

* Renamed Button component for HOF Card


### Did you increase testing or code coverage?

No


### Did you add any dependencies to the project? 

No


### Did you update the relevant documentation?

Soon (TM)
