### PR TITLE
Add CADathon sponsors and partners sections

### DIFF
--- a/web/cadathon-26/src/app/page.tsx
+++ b/web/cadathon-26/src/app/page.tsx
@@ -3,7 +3,9 @@ import FAQ from "~/components/FAQ";
 import Footer from "~/components/Footer";
 import Info from "~/components/Info";
 import Landing from "~/components/Landing";
+import Partners from "~/components/Partners";
 import Schedule from "~/components/Schedule";
+import Sponsors from "~/components/Sponsors";
 
 export default function Home() {
   return (
@@ -17,6 +19,12 @@ export default function Home() {
       <Info />
       <Schedule />
       <FAQ />
+      <Sponsors />
+      <Partners />
+
+      <div className="h-10 sm:h-12">
+        <Checkers marquee />
+      </div>
 
       <Footer />
     </>

--- a/web/cadathon-26/src/components/LogoWall.tsx
+++ b/web/cadathon-26/src/components/LogoWall.tsx
@@ -1,0 +1,90 @@
+import { ReactNode } from "react";
+import RoadTexture from "./RoadTexture";
+
+export interface Logo {
+  /** Full organization name. Used as the image's alt text. */
+  name?: string;
+  /** Short form shown in the placeholder box. Falls back to `name`. */
+  abbr?: string;
+  /** Path in public/, e.g. "/partners/bmes.svg". Renders a placeholder box
+   *  until this is supplied. Color logos are desaturated in CSS, so there's
+   *  no need to grayscale the file itself. */
+  src?: string;
+  /** Makes the slot a link, which is what enables the hover scale. */
+  href?: string;
+}
+
+interface Props {
+  heading: string;
+  logos: Logo[];
+  /** Background and grain color for the section wrapper. */
+  className: string;
+  /** Optional call to action rendered beneath the grid. */
+  children?: ReactNode;
+}
+
+const SLOT =
+  "flex h-24 w-40 items-center justify-center rounded-lg sm:h-28 sm:w-48";
+const PLACEHOLDER =
+  "border-2 border-dashed border-white/40 bg-black/20 px-3 text-center font-heading text-xs leading-tight font-bold tracking-wide text-white/80 uppercase";
+const INTERACTIVE =
+  "group transition duration-200 hover:scale-105 hover:drop-shadow-lg hover:drop-shadow-black/40";
+
+function LogoSlot({ name, abbr, src, href }: Logo) {
+  const body = src ? (
+    <img
+      src={src}
+      alt={name ?? ""}
+      className="max-h-full max-w-full object-contain grayscale transition duration-200 group-hover:grayscale-0"
+    />
+  ) : (
+    (abbr ?? name ?? "Your logo here")
+  );
+
+  // Every slot gets the hover treatment, so placeholders preview the effect
+  // the real logos will have once their links are filled in.
+  const className = [SLOT, src ? "" : PLACEHOLDER, INTERACTIVE]
+    .filter(Boolean)
+    .join(" ");
+
+  return href ? (
+    <a href={href} className={className}>
+      {body}
+    </a>
+  ) : (
+    <div className={className}>{body}</div>
+  );
+}
+
+/**
+ * Shared layout for the Sponsors and Partners sections: a heading over a
+ * centered, wrapping grid of logo slots, with an optional CTA underneath.
+ */
+export default function LogoWall({
+  heading,
+  logos,
+  className,
+  children,
+}: Props) {
+  return (
+    <div className={`relative bg-cover bg-center ${className}`}>
+      <RoadTexture />
+
+      <section className="relative z-0 mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-12 sm:gap-10 sm:px-8 sm:py-16 lg:py-24">
+        <h1 className="text-center font-heading text-3xl font-extrabold tracking-wide text-white text-border-5 text-border-black sm:text-4xl lg:text-5xl">
+          {heading}
+        </h1>
+
+        <ul className="mx-auto flex max-w-2xl flex-wrap justify-center gap-6 sm:gap-8">
+          {logos.map((logo, i) => (
+            <li key={logo.name ?? i}>
+              <LogoSlot {...logo} />
+            </li>
+          ))}
+        </ul>
+
+        {children}
+      </section>
+    </div>
+  );
+}

--- a/web/cadathon-26/src/components/Partners.tsx
+++ b/web/cadathon-26/src/components/Partners.tsx
@@ -1,0 +1,25 @@
+import LogoWall, { Logo } from "./LogoWall";
+
+/**
+ * Partner orgs. Logos render as named placeholder slots until each org's
+ * media kit lands -- drop the file in public/partners/ and set `src`, plus
+ * `href` to make the slot a link.
+ */
+const PARTNERS: Logo[] = [
+  { name: "Biomedical Engineering Society", abbr: "BMES" },
+  { name: "UGA Motorsports" },
+  { name: "American Society of Mechanical Engineers", abbr: "ASME" },
+  { name: "National Society of Black Engineers", abbr: "NSBE" },
+  { name: "Society of Hispanic Professional Engineers", abbr: "SHPE" },
+  { name: "Society of Women Engineers", abbr: "SWE" },
+];
+
+export default function Partners() {
+  return (
+    <LogoWall
+      heading="Partners"
+      logos={PARTNERS}
+      className="bg-pink-500 text-pink-950/25"
+    />
+  );
+}

--- a/web/cadathon-26/src/components/Sponsors.tsx
+++ b/web/cadathon-26/src/components/Sponsors.tsx
@@ -1,0 +1,28 @@
+import LinkButton from "./LinkButton";
+import LogoWall, { Logo } from "./LogoWall";
+
+/**
+ * No sponsors are confirmed yet, so these render as empty placeholder slots.
+ * Fill in `name`, `src`, and `href` per sponsor as they're signed -- adding
+ * `href` is what turns a slot into a link with the hover scale.
+ */
+const SPONSORS: Logo[] = [{}, {}, {}, {}, {}];
+
+/** TODO: point at the sponsorship packet once it exists. */
+const SPONSORSHIP_PACKET = "#";
+
+export default function Sponsors() {
+  return (
+    <LogoWall
+      heading="Sponsors"
+      logos={SPONSORS}
+      className="bg-lime-600 text-lime-950/25"
+    >
+      <p className="self-center text-xl sm:text-2xl">
+        <LinkButton invert href={SPONSORSHIP_PACKET}>
+          Sponsorship Packet
+        </LinkButton>
+      </p>
+    </LogoWall>
+  );
+}


### PR DESCRIPTION
### Description
Closes #582 
>[!WARNING]
>The sponsorship packet button does not currently link anywhere. We'll need to add the download link (or to include the packet under `public/`).
> Similarly, we are waiting on the list of initial sponsors and partners to be finalized; marketing should provide the logos for partners and sponsors at that time.

### Changes
- Add `LogoWall` component (shared by both the "Sponsors" and "Partners" sections)
- Add Partners and Sponsors sections

### Did you increase testing or code coverage?
No

### New Dependencies
No

### Screenshots / GIF (UI/Frontend only)
#### Desktop (`1440px` wide)
<img width="2880" height="10218" alt="Screen Shot 2026-08-05 at 11 23 12" src="https://github.com/user-attachments/assets/a57ececa-3ef5-4e7c-9cc7-16f592dbe4ed" />

#### Mobile (`402px` wide)
<img width="1206" height="13728" alt="Screen Shot 2026-08-05 at 11 23 24" src="https://github.com/user-attachments/assets/4e59cbd7-773b-481c-901f-cbbd6be0964b" />
