### PR TITLE
Add CADathon footer

### DIFF
--- a/web/cadathon-26/src/components/Footer.tsx
+++ b/web/cadathon-26/src/components/Footer.tsx
@@ -1,3 +1,86 @@
+import { IconType } from "react-icons";
+import {
+  RiFacebookFill,
+  RiGithubFill,
+  RiGlobalLine,
+  RiInstagramFill,
+  RiLinkedinFill,
+} from "react-icons/ri";
+import RoadTexture from "./RoadTexture";
+
+const CONTACT_EMAIL = "hello@ugahacks.com";
+
+const LINKS: { name: string; href: string; Icon: IconType }[] = [
+  {
+    name: "Facebook",
+    href: "https://www.facebook.com/ugahacks",
+    Icon: RiFacebookFill,
+  },
+  {
+    name: "Instagram",
+    href: "https://www.instagram.com/ugahacks",
+    Icon: RiInstagramFill,
+  },
+  { name: "GitHub", href: "https://github.com/ugahacks", Icon: RiGithubFill },
+  {
+    name: "LinkedIn",
+    href: "https://www.linkedin.com/company/ugahacks",
+    Icon: RiLinkedinFill,
+  },
+  {
+    name: "UGAHacks website",
+    href: "https://ugahacks.com",
+    Icon: RiGlobalLine,
+  },
+];
+
+const HOVER =
+  "transition duration-200 hover:scale-115 hover:text-pink-300 hover:drop-shadow-lg hover:drop-shadow-black/40";
+
 export default function Footer() {
-  return <footer></footer>;
+  return (
+    <footer className="relative bg-[url(/bg.png)] bg-cover bg-center text-zinc-950/40">
+      {/* Matches the hero's treatment so the page opens and closes the same. */}
+      <div aria-hidden className="absolute inset-0 z-0 bg-zinc-950/45" />
+      <RoadTexture />
+
+      <div className="relative z-0 mx-auto flex w-full max-w-5xl flex-col items-center gap-8 px-4 py-10 text-white sm:py-12">
+        <div className="flex flex-col items-center gap-2">
+          <p className="font-heading text-xs leading-none font-bold tracking-widest uppercase text-border-3 text-border-black">
+            Follow Us
+          </p>
+
+          <ul className="flex items-center gap-5">
+            {LINKS.map(({ name, href, Icon }) => (
+              <li key={name}>
+                <a
+                  href={href}
+                  aria-label={name}
+                  className={`block text-2xl sm:text-3xl ${HOVER}`}
+                >
+                  {/* Stroked to match the outlined treatment on the headings. */}
+                  <Icon className="block stroke-black stroke-[3] [paint-order:stroke]" />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex flex-col items-center gap-2 text-center">
+          <p className="text-sm leading-none font-medium text-border-2 text-border-black sm:text-base">
+            &copy; 2026 UGAHacks. All rights reserved.
+          </p>
+
+          <p className="text-xs leading-none sm:text-sm">
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className={`inline-block font-medium text-border-2 text-border-black ${HOVER}`}
+            >
+              Found a Bug? Let Us Know &rarr;
+            </a>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
 }


### PR DESCRIPTION
### Description
Closes #583 

### Changes
- Added Footer
- Deviation from Figma: added a link to the website, "Spot a Bug" email, and swapped the order of the content (in line with https://2.ugamakes.com/)

### Did you increase testing or code coverage?
No

### New Dependencies
No

### Screenshots / GIF (UI/Frontend only)
#### Desktop (`1440px` wide)
<img width="2880" height="10650" alt="Screen Shot 2026-08-05 at 11 27 10" src="https://github.com/user-attachments/assets/bfb32117-f4f5-4934-bd9d-c297325964d6" />

#### Mobile (`402px` wide)
<img width="1206" height="14298" alt="Screen Shot 2026-08-05 at 11 27 00" src="https://github.com/user-attachments/assets/856b7b16-08b6-4693-b07b-4254341dca1d" />
